### PR TITLE
Update inject.c modify the beginning of the mem block.

### DIFF
--- a/02-ptrace-mmap/inject.c
+++ b/02-ptrace-mmap/inject.c
@@ -188,7 +188,7 @@ int main(int argc, const char* const* argv)
 	}
 
 	/* Write the original rip at the beginning of the mem block */
-	if (0 != ptrace(PTRACE_POKETEXT, pid, regs2.rax, regs1.rip - 2)) {
+	if (0 != ptrace(PTRACE_POKETEXT, pid, regs2.rax, regs1.rip)) {
 		perror("Failed to write return rip to memory");
 		return 1;
 	}


### PR DESCRIPTION
Since the rip interrupted by ptrace is regs1.rip, regs1.rip should be saved at the beginning of the shellcode in order to continue executing the last interrupted rip when completing the shellcode.

if using regs1.reg-2 for others cpu intensive programs, it may occur illegal instruction errors.

The same applies to examples in other directories. Here i only commit this  file.